### PR TITLE
libe2dbg: Turn fprintf with two args into fputs

### DIFF
--- a/libe2dbg/common/common.c
+++ b/libe2dbg/common/common.c
@@ -23,7 +23,7 @@ e2dbgworld_t	e2dbgworld;
 int		e2dbg_output(char *str)
 {
   //revm_output(str);
-  fprintf(stderr, str);
+  fputs(str, stderr);
   return (0);
 }
 

--- a/libe2dbg/user/threads.c
+++ b/libe2dbg/user/threads.c
@@ -285,7 +285,7 @@ void		e2dbg_threads_print()
 	snprintf(logbuf, BUFSIZ, 
 		 " Thread ID %10u %c %8s --[ started on %s from %s \n", 
 		 (unsigned int) cur->tid, c, state, stime, entry);
-	fprintf(stderr, logbuf);
+	fputs(logbuf, stderr);
 	//e2dbg_output(logbuf);
       }
 


### PR DESCRIPTION
When compiling with `-Werror=format-security` this will fail and rightfully so, because as far as I can see all the calls to these functions don't contain any format characters in it and even if that's the case there wouldn't be a way to pass arguments anyway.