### PR TITLE
Fix build on glibc >= 2.28

### DIFF
--- a/librevm/include/revm.h
+++ b/librevm/include/revm.h
@@ -419,7 +419,7 @@ extern int vsscanf(const char * restrict str, const char * restrict format,
 		     va_list ap);
 #elif defined(__linux__)
 extern int vsscanf (__const char *__restrict __s,
-                    __const char *__restrict __format, _G_va_list __arg);
+                    __const char *__restrict __format, __gnuc_va_list __arg);
 #endif
 
 void		wait4exit(void *);


### PR DESCRIPTION
glibc 2.28 [removed](https://lwn.net/Articles/761462/) the `_G_config.h` header, which defined the `_G_va_list` type. This wasn't intended to be a public type. Replace it with `__gnuc_va_list` to fix compilation.