### PR TITLE
Fix compilation for gcc14

### DIFF
--- a/kedbg/register.c
+++ b/kedbg/register.c
@@ -9,37 +9,37 @@
 
 void     kedbg_register_command(void)
 {
-  revm_command_add(CMD_START,     cmd_kedbgcont, NULL, 0, HLP_START);
-  revm_command_add(CMD_CONTINUE,  cmd_kedbgcont, NULL, 0, HLP_CONTINUE);
-  revm_command_add(CMD_CONTINUE2, cmd_kedbgcont, NULL, 0, HLP_CONTINUE);
-  revm_command_add(CMD_CONTINUE3, cmd_kedbgcont, NULL, 0, HLP_CONTINUE);
+  revm_command_add(CMD_START,     (void *)cmd_kedbgcont, NULL, 0, HLP_START);
+  revm_command_add(CMD_CONTINUE,  (void *)cmd_kedbgcont, NULL, 0, HLP_CONTINUE);
+  revm_command_add(CMD_CONTINUE2, (void *)cmd_kedbgcont, NULL, 0, HLP_CONTINUE);
+  revm_command_add(CMD_CONTINUE3, (void *)cmd_kedbgcont, NULL, 0, HLP_CONTINUE);
 
   /* Debugger only script commands */
   revm_command_add(CMD_MODE, cmd_mode, revm_getvarparams, 0, HLP_MODE);
   revm_command_add(CMD_BP, cmd_bp, revm_getvarparams, 0, HLP_BP);
   revm_command_add(CMD_BP2, cmd_bp, revm_getvarparams, 0, HLP_BP);
   revm_command_add(CMD_DELETE, cmd_delete, revm_getvarparams, 0, HLP_DELETE);
-  revm_command_add(CMD_LINKMAP, cmd_linkmap, revm_getvarparams, 1, HLP_LINKMAP);
+  revm_command_add(CMD_LINKMAP, (void *)cmd_linkmap, revm_getvarparams, 1, HLP_LINKMAP);
   revm_command_add(CMD_GOT, cmd_got, revm_getvarparams, 1, HLP_GOT);
-  revm_command_add(CMD_DUMPREGS, cmd_kedbg_dump_regs, revm_getvarparams, 0, HLP_DUMPREGS);
-  revm_command_add(CMD_STEP, cmd_kedbgstep, revm_getvarparams, 0, HLP_STEP);
+  revm_command_add(CMD_DUMPREGS, (void *)cmd_kedbg_dump_regs, revm_getvarparams, 0, HLP_DUMPREGS);
+  revm_command_add(CMD_STEP, (void *)cmd_kedbgstep, revm_getvarparams, 0, HLP_STEP);
   revm_command_add(CMD_BT, cmd_bt, NULL, 0, HLP_BT);
   revm_command_add(CMD_BT2, cmd_bt, NULL, 0, HLP_BT);
   revm_command_add(CMD_DISPLAY, cmd_display, revm_getvarparams, 0, HLP_DISPLAY);
   revm_command_add(CMD_UNDISPLAY, cmd_undisplay, revm_getvarparams, 0, HLP_UNDISPLAY);
   revm_command_add(CMD_RSHT, cmd_rsht, revm_getregxoption, 1, HLP_RSHT);
   revm_command_add(CMD_RPHT, cmd_rpht, revm_getregxoption, 1, HLP_RPHT);
-  revm_command_add(CMD_QUIT, cmd_kedbgquit, NULL, 0, HLP_QUIT);
-  revm_command_add(CMD_QUIT2, cmd_kedbgquit, NULL, 0, HLP_QUIT);
-  revm_command_add(CMD_DISASM, cmd_kedbgdisasm, revm_getdisasm, 0, HLP_DISASM);
-  revm_command_add(CMD_DISASM2, cmd_kedbgdisasm, revm_getdisasm, 0, HLP_DISASM);
-  revm_command_add(CMD_HEXA, cmd_kedbgdisasm, revm_gethexa, 1, HLP_HEXA);
-  revm_command_add(CMD_HEXA2, cmd_kedbgdisasm, revm_gethexa, 1, HLP_HEXA);
-  revm_command_add(CMD_IVT, cmd_kedbgprintivt, NULL, 0, HLP_IVT);
-  revm_command_add(CMD_HOOKIVT, cmd_kedbghookivt, NULL, 0, HLP_HOOKIVT);
+  revm_command_add(CMD_QUIT, (void *)cmd_kedbgquit, NULL, 0, HLP_QUIT);
+  revm_command_add(CMD_QUIT2, (void *)cmd_kedbgquit, NULL, 0, HLP_QUIT);
+  revm_command_add(CMD_DISASM, (void *)cmd_kedbgdisasm, revm_getdisasm, 0, HLP_DISASM);
+  revm_command_add(CMD_DISASM2, (void *)cmd_kedbgdisasm, revm_getdisasm, 0, HLP_DISASM);
+  revm_command_add(CMD_HEXA, (void *)cmd_kedbgdisasm, revm_gethexa, 1, HLP_HEXA);
+  revm_command_add(CMD_HEXA2, (void *)cmd_kedbgdisasm, revm_gethexa, 1, HLP_HEXA);
+  revm_command_add(CMD_IVT, (void *)cmd_kedbgprintivt, NULL, 0, HLP_IVT);
+  revm_command_add(CMD_HOOKIVT, (void *)cmd_kedbghookivt, NULL, 0, HLP_HOOKIVT);
   revm_command_add(CMD_WRITE, cmd_write, revm_getvarparams, 1, HLP_WRITE);
-  revm_command_add(CMD_PROC, cmd_kedbgproc , NULL, 0, HLP_PROC);
-  revm_command_add(CMD_GRAPH, cmd_kedbggraph, revm_getvarparams, 1, HLP_GRAPH);
+  revm_command_add(CMD_PROC, (void *)cmd_kedbgproc , NULL, 0, HLP_PROC);
+  revm_command_add(CMD_GRAPH, (void *)cmd_kedbggraph, revm_getvarparams, 1, HLP_GRAPH);
 
   /* Type related commands */
   revm_command_add(CMD_TYPE     , cmd_type            , revm_getvarparams, 0, HLP_TYPE);
@@ -53,15 +53,15 @@ void     kedbg_register_command(void)
   /* Flow analysis commands */
   revm_command_add(CMD_ANALYSE    , cmd_analyse       , revm_getvarparams, 1, HLP_ANALYSE);
   revm_command_add(CMD_UNSTRIP    , cmd_unstrip       , NULL,            1, HLP_UNSTRIP);
-  revm_command_add(CMD_GRAPH     , cmd_graph         , revm_getvarparams, 1, HLP_GRAPH);
-  revm_command_add(CMD_INSPECT   , cmd_inspect       , revm_getoption,    1, HLP_INSPECT);
-  revm_command_add(CMD_FLOWJACK  , cmd_flowjack      , revm_getoption2,   1, HLP_FLOWJACK);
-  revm_command_add(CMD_ADDGOTO   , cmd_addgoto       , revm_getoption2,   1, HLP_ADDGOTO);
-  revm_command_add(CMD_SETGVL    , cmd_setgvl        , revm_getoption,    1, HLP_SETGVL);
-  revm_command_add(CMD_RENAME     , cmd_rename        , revm_getoption2,   1, HLP_RENAME);  
+  revm_command_add(CMD_GRAPH     , (void *)cmd_graph         , revm_getvarparams, 1, HLP_GRAPH);
+  revm_command_add(CMD_INSPECT   , (void *)cmd_inspect       , revm_getoption,    1, HLP_INSPECT);
+  revm_command_add(CMD_FLOWJACK  , (void *)cmd_flowjack      , revm_getoption2,   1, HLP_FLOWJACK);
+  revm_command_add(CMD_ADDGOTO   , (void *)cmd_addgoto       , revm_getoption2,   1, HLP_ADDGOTO);
+  revm_command_add(CMD_SETGVL    , (void *)cmd_setgvl        , revm_getoption,    1, HLP_SETGVL);
+  revm_command_add(CMD_RENAME     , cmd_rename        , revm_getoption2,   1, HLP_RENAME);
   revm_command_add(CMD_CONTROL   , cmd_control       , NULL,            1, HLP_CONTROL);
 
-  revm_command_add(CMD_ITRACE, cmd_kedbgitrace, NULL, 0, HLP_ITRACE);
+  revm_command_add(CMD_ITRACE, (void *)cmd_kedbgitrace, NULL, 0, HLP_ITRACE);
   /*   revm_command_add(CMD_WATCH    , (void *) cmd_watch    , revm_getvarparams, 1, HLP_WATCH); */
   /*   revm_command_add(CMD_STACK    , (void *) cmd_stack    , revm_getoption,    1, HLP_STACK); */
   /*   revm_command_add(CMD_THREADS  , (void *) cmd_threads  , revm_getvarparams, 1, HLP_THREADS); */

--- a/libe2dbg/user/signal.c
+++ b/libe2dbg/user/signal.c
@@ -425,8 +425,8 @@ void			e2dbg_breakpoint_process()
 	  sect   = elfsh_get_parent_section(parent, (eresi_Addr) *pc, NULL);
 	  name   = revm_resolve(parent, (eresi_Addr) *pc, &off);
 	  off = 0;
-	  sym    = elfsh_get_metasym_by_value(parent, (eresi_Addr) *pc, 
-					      &off, ELFSH_LOWSYM);
+	  sym    = elfsh_get_metasym_by_value(parent, (eresi_Addr) *pc,
+					      (int *)&off, ELFSH_LOWSYM);
 
 #if __DEBUG_BP__
 	  fprintf(stderr, 

--- a/libstderesi/analysis/argcount.c
+++ b/libstderesi/analysis/argcount.c
@@ -36,7 +36,7 @@ int		cmd_argcount()
       if (addr == 0)
 	PROFILER_ERR(__FILE__, __FUNCTION__, __LINE__, 
 		     "Invalid function/address request", -1);
-      name = elfsh_reverse_metasym(world.curjob->curfile, addr, &off);
+      name = elfsh_reverse_metasym(world.curjob->curfile, addr, (elfsh_SAddr *)&off);
       if (!name)
 	name = "func-unresolved";
     }

--- a/libstderesi/cmd/init.c
+++ b/libstderesi/cmd/init.c
@@ -330,11 +330,11 @@ void		eresi_commands_init()
   /* Flow analysis commands */
   revm_command_add(CMD_ANALYSE    , cmd_analyse      , revm_getvarparams, 1, HLP_ANALYSE);
   revm_command_add(CMD_UNSTRIP    , cmd_unstrip       , NULL,             1, HLP_UNSTRIP);
-  revm_command_add(CMD_GRAPH     , cmd_graph         , revm_getvarparams, 1, HLP_GRAPH);
-  revm_command_add(CMD_INSPECT   , cmd_inspect       , revm_getoption,    1, HLP_INSPECT);
-  revm_command_add(CMD_FLOWJACK  , cmd_flowjack      , revm_getoption2,   1, HLP_FLOWJACK);
-  revm_command_add(CMD_ADDGOTO   , cmd_addgoto       , revm_getoption2,   1, HLP_ADDGOTO);
-  revm_command_add(CMD_SETGVL    , cmd_setgvl        , revm_getoption,    1, HLP_SETGVL);
+  revm_command_add(CMD_GRAPH     , (void *)cmd_graph         , revm_getvarparams, 1, HLP_GRAPH);
+  revm_command_add(CMD_INSPECT   , (void *)cmd_inspect       , revm_getoption,    1, HLP_INSPECT);
+  revm_command_add(CMD_FLOWJACK  , (void *)cmd_flowjack      , revm_getoption2,   1, HLP_FLOWJACK);
+  revm_command_add(CMD_ADDGOTO   , (void *)cmd_addgoto       , revm_getoption2,   1, HLP_ADDGOTO);
+  revm_command_add(CMD_SETGVL    , (void *)cmd_setgvl        , revm_getoption,    1, HLP_SETGVL);
   revm_command_add(CMD_RENAME     , cmd_rename        , revm_getoption2,  1, HLP_RENAME);
   revm_command_add(CMD_ASTRIP    , cmd_astrip        , NULL,              1, HLP_ASTRIP);
   revm_command_add(CMD_CONTROL   , cmd_control       , NULL,              1, HLP_CONTROL);


### PR DESCRIPTION
Starting with gcc14, the flag `-Wincompatible-pointer-types` is set by default, and thus forbid to make the program build. To fix this issue, we need to add casts to incompatible pointers:
- Added (void *) casts to functions passed as parameters with fewer arguments
- Added explicit casts to other arguments